### PR TITLE
Fix grammar on SessionOptions.IOTimeout XML documentation

### DIFF
--- a/src/Middleware/Session/src/SessionOptions.cs
+++ b/src/Middleware/Session/src/SessionOptions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Builder
         public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(20);
 
         /// <summary>
-        /// The maximim amount of time allowed to load a session from the store or to commit it back to the store.
+        /// The maximum amount of time allowed to load a session from the store or to commit it back to the store.
         /// Note this may only apply to asynchronous operations. This timeout can be disabled using <see cref="Timeout.InfiniteTimeSpan"/>.
         /// </summary>
         public TimeSpan IOTimeout { get; set; } = TimeSpan.FromMinutes(1);


### PR DESCRIPTION
Fixed grammar on `SessionOptions.IOTimeout`